### PR TITLE
fix: skeleton having top border

### DIFF
--- a/packages/core/theme/src/components/skeleton.ts
+++ b/packages/core/theme/src/components/skeleton.ts
@@ -25,8 +25,6 @@ const skeleton = tv({
       "before:inset-0",
       "before:-translate-x-full",
       "before:animate-[shimmer_2s_infinite]",
-      "before:border-t",
-      "before:border-content4/30",
       "before:bg-gradient-to-r",
       "before:from-transparent",
       "before:via-content4",


### PR DESCRIPTION
This border is extremely visible in dark mode as light bar that moves with the skeleton gradient. Not sure why it was added in the first place.